### PR TITLE
Handle uppercase characters in barcodes correctly

### DIFF
--- a/src/database.rs
+++ b/src/database.rs
@@ -170,7 +170,7 @@ impl Article {
             r#"
             SELECT id, designation, prices
             FROM articles
-            WHERE lower(id) = lower($1)
+            WHERE id = $1
             "#,
         )
         .bind(barcode)

--- a/src/running.rs
+++ b/src/running.rs
@@ -84,7 +84,7 @@ impl RunningClubFridge {
 
     pub fn subscription(&self) -> Subscription<Message> {
         let mut subscriptions = vec![
-            iced::keyboard::on_key_press(|key, _modifiers| Some(Message::KeyPress(key))),
+            iced::keyboard::on_key_press(|key, modifiers| Some(Message::KeyPress(key, modifiers))),
             iced::time::every(SELF_UPDATE_INTERVAL).map(|_| Message::SelfUpdate),
         ];
 
@@ -307,12 +307,17 @@ impl RunningClubFridge {
                     Task::none()
                 });
             }
-            Message::KeyPress(Key::Character(c)) => {
+            Message::KeyPress(Key::Character(c), modifiers) => {
+                let mut c = c.chars().next().unwrap();
+                if modifiers.shift() {
+                    c = c.to_ascii_uppercase();
+                }
+
                 debug!("Key pressed: {c:?}");
-                self.input.push_str(c.as_str());
+                self.input.push(c);
                 self.hide_popup();
             }
-            Message::KeyPress(Key::Named(Named::Enter)) => {
+            Message::KeyPress(Key::Named(Named::Enter), _) => {
                 debug!("Key pressed: Enter");
                 let input = mem::take(&mut self.input);
                 let pool = self.pool.clone();
@@ -334,7 +339,7 @@ impl RunningClubFridge {
                 };
             }
             #[cfg(debug_assertions)]
-            Message::KeyPress(Key::Named(Named::Control)) => {
+            Message::KeyPress(Key::Named(Named::Control), _) => {
                 use rust_decimal_macros::dec;
 
                 let task = if self.user.is_some() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -2,7 +2,7 @@ use crate::database;
 use crate::running::RunningClubFridge;
 use crate::setup::Setup;
 use crate::starting::StartingClubFridge;
-use iced::keyboard::Key;
+use iced::keyboard::{Key, Modifiers};
 use iced::{application, window, Subscription, Task};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::SqlitePool;
@@ -139,7 +139,7 @@ pub enum Message {
     SelfUpdateResult(Result<self_update::Status, Arc<anyhow::Error>>),
     LoadFromVF,
     UploadSalesToVF,
-    KeyPress(Key),
+    KeyPress(Key, Modifiers),
     FindMemberResult {
         input: String,
         result: Result<Option<database::Member>, Arc<sqlx::Error>>,


### PR DESCRIPTION
Instead of ignoring the `Shift` modifier, we apply it correctly, which allows us to remove the `lower()` call from the database query, which should improve the query performance by now being able to take advantage of the primary key index.