### PR TITLE
Add a hidden, touch-friendly log viewer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ self_update = { version = "=0.42.0", default-features = false, features = ["comp
 serde = { version = "=1.0.229", features = ["derive"] }
 serde_json = "=1.0.151"
 sqlx = { version = "=0.9.0", features = ["runtime-tokio", "sqlite"] }
-tokio = { version = "=1.53.1", features = ["time"] }
+tokio = { version = "=1.53.1", features = ["fs", "time"] }
 tracing = "=0.1.44"
 tracing-appender = "=0.2.5"
 tracing-subscriber = "=0.3.23"

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,37 @@
+# Hidden log viewer
+
+## Interaction and layout
+
+The log viewer is a hidden, full-screen application mode with no button or hint on the normal ClubFridge screens. Pressing `Ctrl+L` from startup, setup, or normal operation replaces the current screen with the viewer. Pressing `Ctrl+L` again, pressing `Escape`, or using the **Close** button returns to the previous screen. While the viewer is open, keyboard input is consumed by the viewer and never reaches credential fields or the RFID/barcode input.
+
+Normal application activity continues behind it. Database startup, synchronization, update checks, popup timers, and an active purchase timeout are not paused. A purchase may therefore still complete or cancel automatically while someone reads the logs.
+
+The viewer uses the full 800x480 area. A narrow pane on the left lists regular files matching `clubfridge-neo.*.log`, sorted alphabetically from A to Z. The selected filename is visually highlighted. On each opening, the alphabetically last file is selected, which corresponds to the newest file under the current date-based naming scheme.
+
+The larger right pane displays the selected file in a vertically scrollable, monospace text view. Long lines wrap to the pane width. A header identifies the selected file and provides adjacent **Refresh** and **Close** buttons. Refreshing rescans the directory, re-sorts the file list, preserves the current selection when that file still exists, and reloads its contents. If the selected file disappeared, the newest remaining file becomes selected.
+
+## File loading and failure behavior
+
+Entering the viewer starts a fresh asynchronous scan of the relative `logs/` directory so file access does not block the UI. Only regular files whose names match `clubfridge-neo.*.log` are included. Directory traversal is not supported. Symlinks and subdirectories do not appear in the list.
+
+Selecting a filename loads a complete snapshot of that file asynchronously. The result stays associated with the requested filename so rapidly selecting multiple files cannot allow an older read to replace the newer selection.
+
+**Refresh** performs another directory scan and reloads the selected file. It retains that selection if possible. If the file was removed by log rotation, the newest remaining file is selected. If no files remain, the selection and content pane are cleared. **Close** immediately returns to the underlying application screen. An unfinished read may complete harmlessly but must not reopen or modify the closed viewer.
+
+Expected empty and failure states are displayed inside the viewer instead of normal application popups:
+
+- A missing or empty `logs/` directory shows `Keine Logdateien gefunden.`
+- A directory scan failure shows a short German error message.
+- A selected file that cannot be read shows the error in the content pane while leaving the file list usable.
+- An empty log file shows an empty-state message instead of a blank unexplained pane.
+
+The viewer is read-only. It does not delete, copy, download, search, or modify log files. The initial version reads the complete selected file without imposing a hidden size or line limit.
+
+## Implementation plan
+
+1. Add a focused `log_viewer` module that owns viewer state, directory scanning, file loading, selection reconciliation, and rendering. Reuse shared logging constants for the directory and filename pattern.
+2. Add tests for filename filtering, alphabetical sorting, newest-file selection, selection preservation after refresh, removal fallback, empty directories, and read failures.
+3. Move keyboard listening to the application level so `Ctrl+L` works from every screen without duplicate events. Test that `Ctrl+L` opens or closes the viewer, `Escape` closes it, and shortcut input never enters the scanner buffer.
+4. Add asynchronous messages for scanning, selecting, loading, refreshing, and closing. Ignore load results for files that are no longer selected or a viewer that has closed.
+5. Make the viewer take precedence in `ClubFridge::view()`, including over ordinary popups. Build the two-pane UI with a highlighted selected file, wrapped monospace content, German empty and error states, and adjacent **Refresh** and **Close** buttons.
+6. Run focused tests through red-green-refactor, then the complete test suite, formatter, and Clippy. Review and commit the change without staging the pre-existing `Cargo.lock` modification.

--- a/src/log_viewer.rs
+++ b/src/log_viewer.rs
@@ -1,0 +1,521 @@
+use crate::logging::{LOG_DIRECTORY, LOG_FILENAME_PREFIX, LOG_FILENAME_SUFFIX};
+use crate::state::Message;
+use iced::widget::text::Wrapping;
+use iced::widget::{button, column, container, row, scrollable, text, Column};
+use iced::{color, Center, Element, Fill, Font, Length, Task};
+use std::borrow::Cow;
+use std::io;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+/// A validated directory entry name for an application log file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LogFileName(String);
+
+impl LogFileName {
+    fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn date_label(&self) -> &str {
+        self.0
+            .strip_prefix(LOG_FILENAME_PREFIX)
+            .and_then(|name| name.strip_suffix(LOG_FILENAME_SUFFIX))
+            .expect("log file names are validated during directory scans")
+    }
+}
+
+/// Identifies one opening of the hidden log viewer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LogViewerGeneration(u64);
+
+impl LogViewerGeneration {
+    /// Creates a viewer generation from the app-owned opening counter.
+    pub(crate) fn new(value: u64) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug)]
+enum LogFileSelection {
+    None,
+    Loading(LogFileName),
+    Loaded {
+        file_name: LogFileName,
+        contents: String,
+    },
+    Failed {
+        file_name: LogFileName,
+        error: Arc<io::Error>,
+    },
+}
+
+impl LogFileSelection {
+    fn file_name(&self) -> Option<&LogFileName> {
+        match self {
+            Self::None => None,
+            Self::Loading(file_name)
+            | Self::Loaded { file_name, .. }
+            | Self::Failed { file_name, .. } => Some(file_name),
+        }
+    }
+}
+
+/// The file list, selection, and loaded snapshot shown in the log viewer.
+#[derive(Debug)]
+pub(crate) struct LogViewer {
+    generation: LogViewerGeneration,
+    log_files: Vec<LogFileName>,
+    selection: LogFileSelection,
+    scan_error: Option<Arc<io::Error>>,
+    is_scanning: bool,
+}
+
+impl LogViewer {
+    /// Creates an empty log viewer for one opening of the hidden mode.
+    pub(crate) fn new(generation: LogViewerGeneration) -> Self {
+        Self {
+            generation,
+            log_files: Vec::new(),
+            selection: LogFileSelection::None,
+            scan_error: None,
+            is_scanning: false,
+        }
+    }
+
+    /// Returns the generation that owns this viewer and its async results.
+    pub(crate) fn generation(&self) -> LogViewerGeneration {
+        self.generation
+    }
+
+    /// Reports whether a directory scan or file read is currently running.
+    pub(crate) fn is_busy(&self) -> bool {
+        self.is_scanning || matches!(self.selection, LogFileSelection::Loading(_))
+    }
+
+    /// Starts a fresh scan unless another viewer operation is still running.
+    pub(crate) fn refresh_log_files(&mut self) -> Task<Message> {
+        if self.is_busy() {
+            return Task::none();
+        }
+
+        self.is_scanning = true;
+        self.scan_error = None;
+        scan_log_files_task(self.generation)
+    }
+
+    /// Applies a completed directory scan and loads the retained or newest selection.
+    pub(crate) fn apply_log_file_list_result(
+        &mut self,
+        result: Result<Vec<LogFileName>, Arc<io::Error>>,
+    ) -> Task<Message> {
+        match result {
+            Ok(log_files) => self
+                .apply_log_file_list(log_files)
+                .map_or_else(Task::none, |file_name| {
+                    load_log_file_task(self.generation, file_name)
+                }),
+            Err(error) => {
+                self.scan_error = Some(error);
+                self.is_scanning = false;
+                Task::none()
+            }
+        }
+    }
+
+    /// Selects and loads a log file that is present in the latest directory scan.
+    pub(crate) fn load_selected_log_file(&mut self, file_name: LogFileName) -> Task<Message> {
+        self.select_log_file(file_name)
+            .map_or_else(Task::none, |file_name| {
+                load_log_file_task(self.generation, file_name)
+            })
+    }
+
+    /// Applies file bytes only when they belong to the current selection.
+    pub(crate) fn apply_log_file_contents(
+        &mut self,
+        file_name: LogFileName,
+        result: Result<Vec<u8>, Arc<io::Error>>,
+    ) {
+        if self.selected_log_file() != Some(&file_name) {
+            return;
+        }
+
+        self.selection = match result {
+            Ok(contents) => LogFileSelection::Loaded {
+                file_name,
+                contents: String::from_utf8_lossy(&contents).into_owned(),
+            },
+            Err(error) => LogFileSelection::Failed { file_name, error },
+        };
+    }
+
+    /// Renders the full-screen, read-only application log viewer.
+    pub(crate) fn view(&self) -> Element<'_, Message> {
+        let mut file_list = Column::new().spacing(5);
+
+        if self.is_scanning {
+            let status = if self.log_files.is_empty() {
+                "Logdateien werden geladen…"
+            } else {
+                "Logdateien werden aktualisiert…"
+            };
+            file_list = file_list.push(text(status).size(14));
+        }
+
+        if let Some(error) = &self.scan_error {
+            file_list = file_list.push(
+                text(format!("Logdateien konnten nicht geladen werden: {error}"))
+                    .size(14)
+                    .color(color!(0xD5A30F)),
+            );
+        }
+
+        if self.log_files.is_empty() && !self.is_scanning && self.scan_error.is_none() {
+            file_list = file_list.push(text("Keine Logdateien gefunden.").size(14));
+        }
+
+        for file_name in &self.log_files {
+            let is_selected = self.selected_log_file() == Some(file_name);
+            let style = if is_selected {
+                button::primary
+            } else {
+                button::secondary
+            };
+            let file_button = button(text(file_name.date_label()).size(14))
+                .width(Fill)
+                .padding([8, 10])
+                .style(style);
+            let file_button = if self.is_busy() {
+                file_button
+            } else {
+                file_button.on_press(Message::SelectLogFile(file_name.clone()))
+            };
+            file_list = file_list.push(file_button);
+        }
+
+        let file_list = container(scrollable(file_list).height(Fill))
+            .width(Length::Fixed(140.))
+            .height(Fill)
+            .padding(10)
+            .style(container::bordered_box);
+
+        let selected_file_name = self.selected_log_file().map_or("Logs", LogFileName::as_str);
+        let refresh_button = button(text("Aktualisieren")).padding([8, 12]);
+        let refresh_button = if self.is_busy() {
+            refresh_button
+        } else {
+            refresh_button.on_press(Message::RefreshLogFiles)
+        };
+        let close_button = button(text("Schließen"))
+            .padding([8, 12])
+            .on_press(Message::CloseLogViewer);
+        let header = row![
+            text(selected_file_name)
+                .size(18)
+                .width(Fill)
+                .wrapping(Wrapping::WordOrGlyph),
+            refresh_button,
+            close_button,
+        ]
+        .spacing(10)
+        .align_y(Center);
+
+        let log_contents = text(self.log_file_contents_text())
+            .font(Font::MONOSPACE)
+            .size(14)
+            .width(Fill)
+            .wrapping(Wrapping::WordOrGlyph);
+        let log_contents = container(
+            scrollable(log_contents)
+                .direction(scrollable::Direction::Vertical(
+                    scrollable::Scrollbar::new()
+                        .width(32)
+                        .scroller_width(32)
+                        .spacing(4),
+                ))
+                .height(Fill),
+        )
+        .width(Fill)
+        .height(Fill)
+        .padding(10)
+        .style(container::bordered_box);
+        let contents_pane = column![header, log_contents].width(Fill).spacing(10);
+
+        container(row![file_list, contents_pane].height(Fill).spacing(10))
+            .width(Fill)
+            .height(Fill)
+            .padding([20, 30])
+            .into()
+    }
+
+    fn selected_log_file(&self) -> Option<&LogFileName> {
+        self.selection.file_name()
+    }
+
+    fn apply_log_file_list(&mut self, log_files: Vec<LogFileName>) -> Option<LogFileName> {
+        let selected_file = self
+            .selected_log_file()
+            .filter(|selected| log_files.contains(selected))
+            .cloned()
+            .or_else(|| log_files.last().cloned());
+
+        self.log_files = log_files;
+        self.scan_error = None;
+        self.is_scanning = false;
+        self.selection = selected_file
+            .as_ref()
+            .map_or(LogFileSelection::None, |file_name| {
+                LogFileSelection::Loading(file_name.clone())
+            });
+
+        selected_file
+    }
+
+    fn select_log_file(&mut self, file_name: LogFileName) -> Option<LogFileName> {
+        if self.is_busy() || !self.log_files.contains(&file_name) {
+            return None;
+        }
+
+        self.selection = LogFileSelection::Loading(file_name.clone());
+        Some(file_name)
+    }
+
+    fn log_file_contents_text(&self) -> Cow<'_, str> {
+        match &self.selection {
+            LogFileSelection::None => {
+                if let Some(error) = &self.scan_error {
+                    Cow::Owned(format!("Logdateien konnten nicht geladen werden: {error}"))
+                } else if self.is_scanning {
+                    Cow::Borrowed("Logdateien werden geladen…")
+                } else {
+                    Cow::Borrowed("Keine Logdateien gefunden.")
+                }
+            }
+            LogFileSelection::Loading(_) => Cow::Borrowed("Logdatei wird geladen…"),
+            LogFileSelection::Loaded { contents, .. } if contents.is_empty() => {
+                Cow::Borrowed("Logdatei ist leer.")
+            }
+            LogFileSelection::Loaded { contents, .. } => Cow::Borrowed(contents),
+            LogFileSelection::Failed { error, .. } => {
+                Cow::Owned(format!("Logdatei konnte nicht gelesen werden: {error}"))
+            }
+        }
+    }
+}
+
+fn scan_log_files_task(generation: LogViewerGeneration) -> Task<Message> {
+    Task::future(async move {
+        let result = scan_log_files(PathBuf::from(LOG_DIRECTORY))
+            .await
+            .map_err(Arc::new);
+        Message::LogFileListLoaded { generation, result }
+    })
+}
+
+fn load_log_file_task(generation: LogViewerGeneration, file_name: LogFileName) -> Task<Message> {
+    Task::future(async move {
+        let result = tokio::fs::read(PathBuf::from(LOG_DIRECTORY).join(file_name.as_str()))
+            .await
+            .map_err(Arc::new);
+        Message::LogFileContentsLoaded {
+            generation,
+            file_name,
+            result,
+        }
+    })
+}
+
+async fn scan_log_files(directory: PathBuf) -> io::Result<Vec<LogFileName>> {
+    let mut entries = match tokio::fs::read_dir(directory).await {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => return Err(error),
+    };
+    let mut log_files = Vec::new();
+
+    while let Some(entry) = entries.next_entry().await? {
+        if !entry.file_type().await?.is_file() {
+            continue;
+        }
+
+        let Ok(file_name) = entry.file_name().into_string() else {
+            continue;
+        };
+
+        if file_name.starts_with(LOG_FILENAME_PREFIX) && file_name.ends_with(LOG_FILENAME_SUFFIX) {
+            log_files.push(LogFileName(file_name));
+        }
+    }
+
+    log_files.sort_by(|left, right| left.0.cmp(&right.0));
+    Ok(log_files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    struct TestLogDirectory {
+        path: PathBuf,
+    }
+
+    impl TestLogDirectory {
+        fn new() -> Self {
+            let path = std::env::temp_dir().join(format!(
+                "clubfridge-neo-log-viewer-test-{}",
+                ulid::Ulid::new()
+            ));
+            fs::create_dir(&path).unwrap();
+            Self { path }
+        }
+
+        fn create_file(&self, name: &str) {
+            fs::write(self.path.join(name), "log contents").unwrap();
+        }
+
+        fn create_directory(&self, name: &str) {
+            fs::create_dir(self.path.join(name)).unwrap();
+        }
+    }
+
+    impl Drop for TestLogDirectory {
+        fn drop(&mut self) {
+            fs::remove_dir_all(&self.path).unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn scans_matching_regular_log_files_in_alphabetical_order() {
+        let directory = TestLogDirectory::new();
+        directory.create_file("clubfridge-neo.2026-07-21.log");
+        directory.create_file("clubfridge-neo.2026-07-19.log");
+        directory.create_file("clubfridge-neo.2026-07-20.txt");
+        directory.create_file("other.2026-07-20.log");
+        directory.create_directory("clubfridge-neo.2026-07-18.log");
+
+        let files = scan_log_files(directory.path.clone()).await.unwrap();
+
+        assert_eq!(
+            files,
+            vec![
+                LogFileName("clubfridge-neo.2026-07-19.log".to_string()),
+                LogFileName("clubfridge-neo.2026-07-21.log".to_string()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn treats_a_missing_log_directory_as_an_empty_file_list() {
+        let directory = std::env::temp_dir().join(format!(
+            "clubfridge-neo-missing-log-viewer-test-{}",
+            ulid::Ulid::new()
+        ));
+
+        let files = scan_log_files(directory).await.unwrap();
+
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn derives_date_labels_from_log_file_names() {
+        let file_name = LogFileName("clubfridge-neo.2026-07-21.log".to_string());
+
+        assert_eq!(file_name.date_label(), "2026-07-21");
+    }
+
+    #[test]
+    fn refresh_preserves_the_selection_or_falls_back_to_the_newest_file() {
+        let oldest = LogFileName("clubfridge-neo.2026-07-19.log".to_string());
+        let selected = LogFileName("clubfridge-neo.2026-07-20.log".to_string());
+        let newest = LogFileName("clubfridge-neo.2026-07-21.log".to_string());
+        let mut viewer = LogViewer::new(LogViewerGeneration::new(1));
+
+        assert_eq!(
+            viewer.apply_log_file_list(vec![oldest.clone(), selected.clone()]),
+            Some(selected.clone())
+        );
+        assert_eq!(viewer.selected_log_file(), Some(&selected));
+
+        viewer.apply_log_file_contents(selected.clone(), Ok(Vec::new()));
+        assert_eq!(viewer.select_log_file(oldest.clone()), Some(oldest.clone()));
+        viewer.apply_log_file_contents(oldest.clone(), Ok(Vec::new()));
+        assert_eq!(
+            viewer.apply_log_file_list(vec![oldest.clone(), newest.clone()]),
+            Some(oldest.clone())
+        );
+        assert_eq!(viewer.selected_log_file(), Some(&oldest));
+
+        viewer.apply_log_file_contents(oldest, Ok(Vec::new()));
+        assert_eq!(
+            viewer.apply_log_file_list(vec![selected, newest.clone()]),
+            Some(newest.clone())
+        );
+        assert_eq!(viewer.selected_log_file(), Some(&newest));
+
+        viewer.apply_log_file_contents(newest, Ok(Vec::new()));
+        assert_eq!(viewer.apply_log_file_list(Vec::new()), None);
+        assert_eq!(viewer.selected_log_file(), None);
+    }
+
+    #[test]
+    fn serializes_log_file_scans_and_reads() {
+        let first = LogFileName("clubfridge-neo.2026-07-20.log".to_string());
+        let second = LogFileName("clubfridge-neo.2026-07-21.log".to_string());
+        let mut viewer = LogViewer::new(LogViewerGeneration::new(1));
+
+        drop(viewer.refresh_log_files());
+        assert!(viewer.is_busy());
+
+        viewer.apply_log_file_list(vec![first.clone(), second.clone()]);
+        assert!(viewer.is_busy());
+        assert_eq!(viewer.select_log_file(first.clone()), None);
+
+        viewer.apply_log_file_contents(second, Ok(b"latest contents".to_vec()));
+        assert!(!viewer.is_busy());
+        assert_eq!(viewer.select_log_file(first.clone()), Some(first));
+    }
+
+    #[test]
+    fn ignores_file_contents_for_a_stale_selection() {
+        let old_selection = LogFileName("clubfridge-neo.2026-07-20.log".to_string());
+        let current_selection = LogFileName("clubfridge-neo.2026-07-21.log".to_string());
+        let mut viewer = LogViewer::new(LogViewerGeneration::new(1));
+        viewer.apply_log_file_list(vec![old_selection.clone(), current_selection.clone()]);
+
+        viewer.apply_log_file_contents(old_selection, Ok(b"stale contents".to_vec()));
+        assert_eq!(viewer.log_file_contents_text(), "Logdatei wird geladen…");
+
+        viewer.apply_log_file_contents(current_selection, Ok(b"current \xffcontents".to_vec()));
+        assert_eq!(viewer.log_file_contents_text(), "current \u{fffd}contents");
+    }
+
+    #[test]
+    fn describes_empty_files_and_read_failures_in_german() {
+        let file_name = LogFileName("clubfridge-neo.2026-07-21.log".to_string());
+        let mut viewer = LogViewer::new(LogViewerGeneration::new(1));
+
+        viewer.apply_log_file_list(Vec::new());
+        assert_eq!(
+            viewer.log_file_contents_text(),
+            "Keine Logdateien gefunden."
+        );
+
+        viewer.apply_log_file_list(vec![file_name.clone()]);
+        viewer.apply_log_file_contents(file_name.clone(), Ok(Vec::new()));
+        assert_eq!(viewer.log_file_contents_text(), "Logdatei ist leer.");
+
+        viewer.apply_log_file_contents(
+            file_name,
+            Err(Arc::new(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "Zugriff verweigert",
+            ))),
+        );
+        assert_eq!(
+            viewer.log_file_contents_text(),
+            "Logdatei konnte nicht gelesen werden: Zugriff verweigert"
+        );
+    }
+}

--- a/src/log_viewer.rs
+++ b/src/log_viewer.rs
@@ -1,12 +1,17 @@
 use crate::logging::{LOG_DIRECTORY, LOG_FILENAME_PREFIX, LOG_FILENAME_SUFFIX};
 use crate::state::Message;
 use iced::widget::text::Wrapping;
-use iced::widget::{button, column, container, row, scrollable, text, Column};
-use iced::{color, Center, Element, Fill, Font, Length, Task};
+use iced::widget::{button, column, container, rich_text, row, scrollable, span, text, Column};
+use iced::{color, Center, Color, Element, Fill, Font, Length, Task};
 use std::borrow::Cow;
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
+
+const ERROR_LOG_LINE_COLOR: Color = color!(0xFF5555);
+const WARN_LOG_LINE_COLOR: Color = color!(0xD5A30F);
+const DEBUG_LOG_LINE_COLOR: Color = color!(0x7AA2C8);
+const TRACE_LOG_LINE_COLOR: Color = color!(0x888888);
 
 /// A validated directory entry name for an application log file.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -58,6 +63,23 @@ impl LogFileSelection {
             | Self::Loaded { file_name, .. }
             | Self::Failed { file_name, .. } => Some(file_name),
         }
+    }
+}
+
+fn log_line_color(line: &str) -> Option<Color> {
+    let mut fields = line.split_ascii_whitespace();
+    let timestamp = fields.next()?;
+
+    if timestamp.as_bytes().get(10) != Some(&b'T') {
+        return None;
+    }
+
+    match fields.next() {
+        Some("ERROR") => Some(ERROR_LOG_LINE_COLOR),
+        Some("WARN") => Some(WARN_LOG_LINE_COLOR),
+        Some("DEBUG") => Some(DEBUG_LOG_LINE_COLOR),
+        Some("TRACE") => Some(TRACE_LOG_LINE_COLOR),
+        _ => None,
     }
 }
 
@@ -221,7 +243,7 @@ impl LogViewer {
         .spacing(10)
         .align_y(Center);
 
-        let log_contents = text(self.log_file_contents_text())
+        let log_contents = rich_text(self.log_file_contents_spans())
             .font(Font::MONOSPACE)
             .size(14)
             .width(Fill)
@@ -300,6 +322,16 @@ impl LogViewer {
             LogFileSelection::Failed { error, .. } => {
                 Cow::Owned(format!("Logdatei konnte nicht gelesen werden: {error}"))
             }
+        }
+    }
+
+    fn log_file_contents_spans(&self) -> Vec<text::Span<'_, (), Font>> {
+        match &self.selection {
+            LogFileSelection::Loaded { contents, .. } if !contents.is_empty() => contents
+                .split_inclusive('\n')
+                .map(|line| span(line).color_maybe(log_line_color(line)))
+                .collect(),
+            _ => vec![span(self.log_file_contents_text())],
         }
     }
 }
@@ -423,6 +455,70 @@ mod tests {
         let file_name = LogFileName("clubfridge-neo.2026-07-21.log".to_string());
 
         assert_eq!(file_name.date_label(), "2026-07-21");
+    }
+
+    #[test]
+    fn colors_log_lines_by_the_compact_formatter_level() {
+        assert_eq!(
+            log_line_color("2026-07-21T12:00:00.001Z ERROR clubfridge_neo: failed"),
+            Some(ERROR_LOG_LINE_COLOR)
+        );
+        assert_eq!(
+            log_line_color("2026-07-21T12:00:00.001Z  WARN clubfridge_neo: warning"),
+            Some(WARN_LOG_LINE_COLOR)
+        );
+        assert_eq!(
+            log_line_color("2026-07-21T12:00:00.001Z  INFO clubfridge_neo: started"),
+            None
+        );
+        assert_eq!(
+            log_line_color("2026-07-21T12:00:00.001Z DEBUG clubfridge_neo: update"),
+            Some(DEBUG_LOG_LINE_COLOR)
+        );
+        assert_eq!(
+            log_line_color("2026-07-21T12:00:00.001Z TRACE clubfridge_neo: detail"),
+            Some(TRACE_LOG_LINE_COLOR)
+        );
+    }
+
+    #[test]
+    fn does_not_color_level_words_outside_the_compact_level_column() {
+        assert_eq!(
+            log_line_color("2026-07-21T12:00:00.001Z  INFO clubfridge_neo: ERROR was handled"),
+            None
+        );
+        assert_eq!(log_line_color("continuation ERROR from nested error"), None);
+        assert_eq!(log_line_color("continuation mentioning WARN"), None);
+    }
+
+    #[test]
+    fn creates_one_colored_span_for_each_log_line() {
+        let file_name = LogFileName("clubfridge-neo.2026-07-21.log".to_string());
+        let mut viewer = LogViewer::new(LogViewerGeneration::new(1));
+        viewer.apply_log_file_list(vec![file_name.clone()]);
+        viewer.apply_log_file_contents(
+            file_name,
+            Ok(concat!(
+                "2026-07-21T12:00:00.001Z ERROR clubfridge_neo: failed\n",
+                "2026-07-21T12:00:01.001Z  INFO clubfridge_neo: recovered"
+            )
+            .as_bytes()
+            .to_vec()),
+        );
+
+        let spans = viewer.log_file_contents_spans();
+
+        assert_eq!(spans.len(), 2);
+        assert_eq!(
+            spans[0].text,
+            "2026-07-21T12:00:00.001Z ERROR clubfridge_neo: failed\n"
+        );
+        assert_eq!(spans[0].color, Some(ERROR_LOG_LINE_COLOR));
+        assert_eq!(
+            spans[1].text,
+            "2026-07-21T12:00:01.001Z  INFO clubfridge_neo: recovered"
+        );
+        assert_eq!(spans[1].color, None);
     }
 
     #[test]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -5,6 +5,15 @@ use tracing_subscriber::Layer;
 
 const DEFAULT_TARGETS: &str = "warn,clubfridge_neo=debug";
 
+/// The process-relative directory that contains application log files.
+pub(crate) const LOG_DIRECTORY: &str = "logs";
+
+/// The filename prefix that identifies application log files.
+pub(crate) const LOG_FILENAME_PREFIX: &str = "clubfridge-neo.";
+
+/// The filename suffix that identifies application log files.
+pub(crate) const LOG_FILENAME_SUFFIX: &str = ".log";
+
 pub fn init() -> anyhow::Result<()> {
     let targets = targets_from_env();
 
@@ -14,10 +23,10 @@ pub fn init() -> anyhow::Result<()> {
 
     let file_appender = tracing_appender::rolling::Builder::new()
         .rotation(tracing_appender::rolling::Rotation::DAILY)
-        .filename_prefix("clubfridge-neo")
-        .filename_suffix("log")
+        .filename_prefix(LOG_FILENAME_PREFIX.trim_end_matches('.'))
+        .filename_suffix(LOG_FILENAME_SUFFIX.trim_start_matches('.'))
         .max_log_files(7)
-        .build("logs")?;
+        .build(LOG_DIRECTORY)?;
 
     let logfile_layer = tracing_subscriber::fmt::layer()
         .compact()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod database;
+mod log_viewer;
 mod logging;
 mod popup;
 mod running;

--- a/src/running.rs
+++ b/src/running.rs
@@ -2,6 +2,8 @@ use crate::database;
 use crate::state::{GlobalState, Message};
 use iced::keyboard::key::Named;
 use iced::keyboard::Key;
+#[cfg(debug_assertions)]
+use iced::keyboard::Modifiers;
 use iced::{Subscription, Task};
 use rust_decimal::Decimal;
 use sqlx::types::Text;
@@ -23,6 +25,14 @@ const SALES_INTERVAL: Duration = Duration::from_secs(10 * 60);
 
 /// The time after which the sale is automatically processed.
 const INTERACTION_TIMEOUT: jiff::SignedDuration = jiff::SignedDuration::from_secs(60);
+
+#[cfg(debug_assertions)]
+fn is_fake_data_shortcut(key: &Key, modifiers: Modifiers) -> bool {
+    modifiers.control()
+        && !modifiers.alt()
+        && !modifiers.logo()
+        && matches!(key, Key::Character(character) if character.eq_ignore_ascii_case("f"))
+}
 
 pub struct RunningClubFridge {
     pub pool: SqlitePool,
@@ -63,13 +73,7 @@ impl RunningClubFridge {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        let mut subscriptions = vec![iced::keyboard::listen().filter_map(|event| {
-            if let iced::keyboard::Event::KeyPressed { key, modifiers, .. } = event {
-                Some(Message::KeyPress(key, modifiers))
-            } else {
-                None
-            }
-        })];
+        let mut subscriptions: Vec<Subscription<Message>> = Vec::new();
 
         if self.vereinsflieger.is_some() {
             subscriptions.push(iced::time::every(SYNC_INTERVAL).map(|_| Message::LoadFromVF));
@@ -82,6 +86,32 @@ impl RunningClubFridge {
         }
 
         Subscription::batch(subscriptions)
+    }
+}
+
+#[cfg(all(test, debug_assertions))]
+mod tests {
+    use super::*;
+    use iced::keyboard::Modifiers;
+
+    #[test]
+    fn recognizes_only_ctrl_f_as_the_fake_data_shortcut() {
+        assert!(is_fake_data_shortcut(
+            &Key::Character("f".into()),
+            Modifiers::CTRL
+        ));
+        assert!(is_fake_data_shortcut(
+            &Key::Character("F".into()),
+            Modifiers::CTRL | Modifiers::SHIFT
+        ));
+        assert!(!is_fake_data_shortcut(
+            &Key::Character("l".into()),
+            Modifiers::CTRL
+        ));
+        assert!(!is_fake_data_shortcut(
+            &Key::Named(Named::Control),
+            Modifiers::CTRL
+        ));
     }
 }
 
@@ -245,39 +275,8 @@ impl RunningClubFridge {
                     Task::none()
                 });
             }
-            Message::KeyPress(Key::Character(c), modifiers) => {
-                let mut c = c.chars().next().unwrap();
-                if modifiers.shift() {
-                    c = c.to_ascii_uppercase();
-                }
-
-                debug!("Key pressed: {c:?}");
-                self.input.push(c);
-                global_state.hide_popup();
-            }
-            Message::KeyPress(Key::Named(Named::Enter), _) => {
-                debug!("Key pressed: Enter");
-                let input = mem::take(&mut self.input);
-                let pool = self.pool.clone();
-
-                global_state.hide_popup();
-
-                return if self.user.is_some() {
-                    Task::future(async move {
-                        let result = database::Article::find_by_barcode(pool, &input).await;
-                        let result = result.map_err(Arc::new);
-                        Message::FindArticleResult { input, result }
-                    })
-                } else {
-                    Task::future(async move {
-                        let result = database::Member::find_by_keycode(pool, &input).await;
-                        let result = result.map_err(Arc::new);
-                        Message::FindMemberResult { input, result }
-                    })
-                };
-            }
             #[cfg(debug_assertions)]
-            Message::KeyPress(Key::Named(Named::Control), _) => {
+            Message::KeyPress(key, modifiers) if is_fake_data_shortcut(&key, modifiers) => {
                 use rust_decimal_macros::dec;
 
                 let task = if self.user.is_some() {
@@ -323,6 +322,37 @@ impl RunningClubFridge {
                 global_state.hide_popup();
 
                 return task;
+            }
+            Message::KeyPress(Key::Character(c), modifiers) => {
+                let mut c = c.chars().next().unwrap();
+                if modifiers.shift() {
+                    c = c.to_ascii_uppercase();
+                }
+
+                debug!("Key pressed: {c:?}");
+                self.input.push(c);
+                global_state.hide_popup();
+            }
+            Message::KeyPress(Key::Named(Named::Enter), _) => {
+                debug!("Key pressed: Enter");
+                let input = mem::take(&mut self.input);
+                let pool = self.pool.clone();
+
+                global_state.hide_popup();
+
+                return if self.user.is_some() {
+                    Task::future(async move {
+                        let result = database::Article::find_by_barcode(pool, &input).await;
+                        let result = result.map_err(Arc::new);
+                        Message::FindArticleResult { input, result }
+                    })
+                } else {
+                    Task::future(async move {
+                        let result = database::Member::find_by_keycode(pool, &input).await;
+                        let result = result.map_err(Arc::new);
+                        Message::FindMemberResult { input, result }
+                    })
+                };
             }
             Message::FindArticleResult { input, result } => match result {
                 Ok(Some(article)) => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,5 @@
 use crate::database;
+use crate::log_viewer::{LogFileName, LogViewer, LogViewerGeneration};
 use crate::popup::Popup;
 use crate::running::RunningClubFridge;
 use crate::setup::Setup;
@@ -42,6 +43,9 @@ pub struct GlobalState {
     pub self_updated: Option<String>,
 
     pub popup: Option<Popup>,
+
+    /// The hidden log viewer, when it is open over the application screen.
+    pub log_viewer: Option<LogViewer>,
 }
 
 impl GlobalState {
@@ -76,6 +80,7 @@ impl GlobalState {
 pub struct ClubFridge {
     pub global_state: GlobalState,
     pub state: State,
+    next_log_viewer_generation: u64,
 }
 
 /// The different states (or screens) the application can be in.
@@ -138,11 +143,13 @@ impl ClubFridge {
             options,
             self_updated: None,
             popup,
+            log_viewer: None,
         };
 
         let cf = Self {
             global_state,
             state: State::Starting(StartingClubFridge::new()),
+            next_log_viewer_generation: 1,
         };
 
         (cf, startup_task)
@@ -157,12 +164,80 @@ impl ClubFridge {
 
         Subscription::batch([
             subscription,
+            iced::keyboard::listen().filter_map(|event| match event {
+                iced::keyboard::Event::KeyPressed {
+                    key,
+                    modifiers,
+                    repeat,
+                    ..
+                } if !is_repeated_control_shortcut(repeat, modifiers) => {
+                    Some(Message::KeyPress(key, modifiers))
+                }
+                _ => None,
+            }),
             iced::time::every(SELF_UPDATE_INTERVAL).map(|_| Message::SelfUpdate),
         ])
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message {
+            Message::KeyPress(key, modifiers) if is_log_viewer_shortcut(&key, modifiers) => {
+                if self.global_state.log_viewer.take().is_some() {
+                    return Task::none();
+                }
+
+                let generation = LogViewerGeneration::new(self.next_log_viewer_generation);
+                self.next_log_viewer_generation += 1;
+                let mut log_viewer = LogViewer::new(generation);
+                let task = log_viewer.refresh_log_files();
+                self.global_state.log_viewer = Some(log_viewer);
+                return task;
+            }
+
+            Message::KeyPress(Key::Named(iced::keyboard::key::Named::Escape), _)
+                if self.global_state.log_viewer.is_some() =>
+            {
+                self.global_state.log_viewer = None;
+            }
+
+            Message::KeyPress(_, _) if self.global_state.log_viewer.is_some() => {}
+
+            Message::RefreshLogFiles => {
+                if let Some(log_viewer) = &mut self.global_state.log_viewer {
+                    return log_viewer.refresh_log_files();
+                }
+            }
+
+            Message::CloseLogViewer => {
+                self.global_state.log_viewer = None;
+            }
+
+            Message::LogFileListLoaded { generation, result } => {
+                if let Some(log_viewer) = &mut self.global_state.log_viewer {
+                    if log_viewer.generation() == generation {
+                        return log_viewer.apply_log_file_list_result(result);
+                    }
+                }
+            }
+
+            Message::SelectLogFile(file_name) => {
+                if let Some(log_viewer) = &mut self.global_state.log_viewer {
+                    return log_viewer.load_selected_log_file(file_name);
+                }
+            }
+
+            Message::LogFileContentsLoaded {
+                generation,
+                file_name,
+                result,
+            } => {
+                if let Some(log_viewer) = &mut self.global_state.log_viewer {
+                    if log_viewer.generation() == generation {
+                        log_viewer.apply_log_file_contents(file_name, result);
+                    }
+                }
+            }
+
             Message::GotoSetup(pool) => {
                 self.state = State::Setup(Setup::new(pool));
             }
@@ -210,6 +285,17 @@ impl ClubFridge {
 
         Task::none()
     }
+}
+
+fn is_log_viewer_shortcut(key: &Key, modifiers: Modifiers) -> bool {
+    modifiers.control()
+        && !modifiers.alt()
+        && !modifiers.logo()
+        && matches!(key, Key::Character(character) if character.eq_ignore_ascii_case("l"))
+}
+
+fn is_repeated_control_shortcut(repeat: bool, modifiers: Modifiers) -> bool {
+    repeat && modifiers.control()
 }
 
 async fn self_update(self_updated: Option<String>) -> anyhow::Result<self_update::Status> {
@@ -278,6 +364,23 @@ pub enum Message {
     UploadSalesToVF,
     /// The application received a key press event.
     KeyPress(Key, Modifiers),
+    /// The user requested another scan of the application log directory.
+    RefreshLogFiles,
+    /// The user closed the hidden log viewer.
+    CloseLogViewer,
+    /// A scan of the application log directory completed.
+    LogFileListLoaded {
+        generation: LogViewerGeneration,
+        result: Result<Vec<LogFileName>, Arc<std::io::Error>>,
+    },
+    /// The user selected a file in the hidden log viewer.
+    SelectLogFile(LogFileName),
+    /// A selected application log file finished loading.
+    LogFileContentsLoaded {
+        generation: LogViewerGeneration,
+        file_name: LogFileName,
+        result: Result<Vec<u8>, Arc<std::io::Error>>,
+    },
     /// A "find member by keycode" query finished.
     FindMemberResult {
         input: String,
@@ -308,10 +411,85 @@ pub enum Message {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use iced::keyboard::key::Named;
 
     #[tokio::test]
     async fn test_initial_state() {
         let (cf, _) = ClubFridge::new(Default::default());
         assert!(matches!(cf.state, State::Starting(_)));
+    }
+
+    #[tokio::test]
+    async fn log_viewer_shortcuts_toggle_globally_and_consume_scanner_input() {
+        let (mut cf, _) = ClubFridge::new(Default::default());
+        let pool = SqlitePool::connect_lazy("sqlite::memory:").unwrap();
+        let (running, _) = RunningClubFridge::new(pool, None);
+        cf.state = State::Running(running);
+
+        drop(cf.update(Message::KeyPress(
+            Key::Character("l".into()),
+            Modifiers::CTRL,
+        )));
+        assert!(cf.global_state.log_viewer.is_some());
+        let first_generation = cf.global_state.log_viewer.as_ref().unwrap().generation();
+
+        drop(cf.update(Message::KeyPress(
+            Key::Character("1".into()),
+            Modifiers::empty(),
+        )));
+        let State::Running(running) = &cf.state else {
+            panic!("expected the running state");
+        };
+        assert!(running.input.is_empty());
+
+        drop(cf.update(Message::KeyPress(
+            Key::Named(Named::Escape),
+            Modifiers::empty(),
+        )));
+        assert!(cf.global_state.log_viewer.is_none());
+
+        drop(cf.update(Message::KeyPress(
+            Key::Character("l".into()),
+            Modifiers::CTRL,
+        )));
+        drop(cf.update(Message::CloseLogViewer));
+        assert!(cf.global_state.log_viewer.is_none());
+
+        drop(cf.update(Message::KeyPress(
+            Key::Character("L".into()),
+            Modifiers::CTRL | Modifiers::SHIFT,
+        )));
+        assert!(cf.global_state.log_viewer.is_some());
+        let second_generation = cf.global_state.log_viewer.as_ref().unwrap().generation();
+        assert_ne!(first_generation, second_generation);
+
+        drop(cf.update(Message::LogFileListLoaded {
+            generation: first_generation,
+            result: Ok(Vec::new()),
+        }));
+        assert!(cf.global_state.log_viewer.as_ref().unwrap().is_busy());
+
+        drop(cf.update(Message::LogFileListLoaded {
+            generation: second_generation,
+            result: Ok(Vec::new()),
+        }));
+        assert!(!cf.global_state.log_viewer.as_ref().unwrap().is_busy());
+
+        drop(cf.update(Message::KeyPress(
+            Key::Character("l".into()),
+            Modifiers::CTRL,
+        )));
+        assert!(cf.global_state.log_viewer.is_none());
+    }
+
+    #[test]
+    fn ignores_repeated_control_shortcuts() {
+        assert!(is_repeated_control_shortcut(true, Modifiers::CTRL));
+        assert!(is_repeated_control_shortcut(
+            true,
+            Modifiers::CTRL | Modifiers::SHIFT
+        ));
+        assert!(!is_repeated_control_shortcut(false, Modifiers::CTRL));
+        assert!(!is_repeated_control_shortcut(true, Modifiers::empty()));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -24,6 +24,10 @@ impl ClubFridge {
     }
 
     pub fn view(&self) -> Element<'_, Message> {
+        if let Some(log_viewer) = &self.global_state.log_viewer {
+            return log_viewer.view();
+        }
+
         let content = match &self.state {
             State::Starting(cf) => cf.view(),
             State::Setup(cf) => cf.view(),


### PR DESCRIPTION
Adds a hidden, full-screen log viewer that can be toggled from any application screen with <kbd>Ctrl</kbd>+<kbd>L</kbd>. It lists the available rotating log files by date and displays the selected file in a wrapped, monospace pane with level-based coloring, asynchronous loading, refresh and close controls, empty and error states, and a touchscreen-friendly scrollbar.

Keyboard input is isolated from normal setup and scanner handling while the viewer is open, and stale asynchronous results cannot replace the current selection. The debug fake-data shortcut moves to <kbd>Ctrl</kbd>+<kbd>F</kbd> to avoid conflicting with the global viewer shortcut.

<img width="912" height="620" alt="screenshot" src="https://github.com/user-attachments/assets/1fbf974d-c5f2-43ec-8570-3277a361adfc" />
